### PR TITLE
Wrap attention mask print

### DIFF
--- a/content/en/posts/2025-01-16-group-query-attention/multi_head_attention.py
+++ b/content/en/posts/2025-01-16-group-query-attention/multi_head_attention.py
@@ -42,8 +42,8 @@ class MultiHeadAttention(nn.Module):
         attention_val = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(self.head_dim)
 
         print(f"attention_val shape is {attention_val.size()}")
-        print(f"attention_mask shape is {attention_mask.size()}")
         if attention_mask is not None:
+            print(f"attention_mask shape is {attention_mask.size()}")
             # If attention_mask is provided, it should have shape (batch_size, nums_head, seq_len, seq_len).
             assert attention_val.size() == attention_mask.size()
             attention_val = torch.masked_fill(attention_val, attention_mask == 0, float("-inf"))

--- a/content/zh/posts/2025-01-16-group-query-attention/multi_head_attention.py
+++ b/content/zh/posts/2025-01-16-group-query-attention/multi_head_attention.py
@@ -42,8 +42,8 @@ class MultiHeadAttention(nn.Module):
         attention_val = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(self.head_dim)
 
         print(f"attention_val shape is {attention_val.size()}")
-        print(f"attention_mask shape is {attention_mask.size()}")
         if attention_mask is not None:
+            print(f"attention_mask shape is {attention_mask.size()}")
             # If attention_mask is provided, it should have shape (batch_size, nums_head, seq_len, seq_len).
             assert attention_val.size() == attention_mask.size()
             attention_val = torch.masked_fill(attention_val, attention_mask == 0, float("-inf"))


### PR DESCRIPTION
## Summary
- fix multi_head_attention logging when mask is omitted

## Testing
- `python content/en/posts/2025-01-16-group-query-attention/multi_head_attention.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6845ac632534832280e9ab3381f06b58