### PR TITLE
Fix typo in group query attention docs

### DIFF
--- a/content/en/posts/2025-01-16-group-query-attention/index.md
+++ b/content/en/posts/2025-01-16-group-query-attention/index.md
@@ -267,7 +267,7 @@ class MultiHeadAttention(nn.Module):
         # resulting in a non-contiguous tensor. The contiguous() method makes the tensor contiguous in memory,
         # allowing subsequent view or reshape operations without error.
         output_tmp = output_tmp.transpose(1, 2).contiguous().view(batch_size, seq_len, self.hidden_dim)
-        # output = output_mid.permute(0, 2, 1, 3).reshpae(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
+        # output = output_mid.permute(0, 2, 1, 3).reshape(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
 
         output = self.output_proj(output_tmp)
         return output

--- a/content/en/posts/2025-01-16-group-query-attention/multi_head_attention.py
+++ b/content/en/posts/2025-01-16-group-query-attention/multi_head_attention.py
@@ -67,7 +67,7 @@ class MultiHeadAttention(nn.Module):
         # resulting in a non-contiguous tensor. The contiguous() method makes the tensor contiguous in memory,
         # allowing subsequent view or reshape operations without error.
         output_tmp = output_tmp.transpose(1, 2).contiguous().view(batch_size, seq_len, self.hidden_dim)
-        # output = output_mid.permute(0, 2, 1, 3).reshpae(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
+        # output = output_mid.permute(0, 2, 1, 3).reshape(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
 
         output = self.output_proj(output_tmp)
         return output

--- a/content/zh/posts/2025-01-16-group-query-attention/index.md
+++ b/content/zh/posts/2025-01-16-group-query-attention/index.md
@@ -266,7 +266,7 @@ class MultiHeadAttention(nn.Module):
         # resulting in a non-contiguous tensor. The contiguous() method makes the tensor contiguous in memory,
         # allowing subsequent view or reshape operations without error.
         output_tmp = output_tmp.transpose(1, 2).contiguous().view(batch_size, seq_len, self.hidden_dim)
-        # output = output_mid.permute(0, 2, 1, 3).reshpae(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
+        # output = output_mid.permute(0, 2, 1, 3).reshape(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
 
         output = self.output_proj(output_tmp)
         return output

--- a/content/zh/posts/2025-01-16-group-query-attention/multi_head_attention.py
+++ b/content/zh/posts/2025-01-16-group-query-attention/multi_head_attention.py
@@ -67,7 +67,7 @@ class MultiHeadAttention(nn.Module):
         # resulting in a non-contiguous tensor. The contiguous() method makes the tensor contiguous in memory,
         # allowing subsequent view or reshape operations without error.
         output_tmp = output_tmp.transpose(1, 2).contiguous().view(batch_size, seq_len, self.hidden_dim)
-        # output = output_mid.permute(0, 2, 1, 3).reshpae(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
+        # output = output_mid.permute(0, 2, 1, 3).reshape(batch_size, seq_len, self.hidden_dim)  # # [Another approach to do it]
 
         output = self.output_proj(output_tmp)
         return output


### PR DESCRIPTION
## Summary
- fix `reshpae` typo in group-query-attention examples in English and Chinese posts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68463190c6f08322b9fdcf7d467c0d6b