### PR TITLE
Fix spacing in attention mask checks

### DIFF
--- a/content/en/posts/2025-01-16-group-query-attention/group_query_attention.py
+++ b/content/en/posts/2025-01-16-group-query-attention/group_query_attention.py
@@ -30,7 +30,7 @@ class GQABroadcast(nn.Module):
         self.v_proj = nn.Linear(hidden_dim, nums_kv_head * self.head_dim)
         self.output_proj = nn.Linear(hidden_dim, hidden_dim)
 
-    def forward(self, x, attention_mask= None):
+    def forward(self, x, attention_mask=None):
         batch_size, seq_len, _ = x.size()
         Q = self.q_proj(x)  # (batch_size, seq_len, hidden_dim)
         K = self.k_proj(x)  # (batch_size, seq_len, nums_kv_head * head_dim)

--- a/content/en/posts/2025-01-16-group-query-attention/multi_query_attention.py
+++ b/content/en/posts/2025-01-16-group-query-attention/multi_query_attention.py
@@ -36,7 +36,7 @@ class MultiQueryAttention(nn.Module):
         attention_val = (q @ k.transpose(-1, -2)) / math.sqrt(self.head_dim)
         print(f"attention_val  shape is {attention_val.size()}")
 
-        if  attention_mask is not None:
+        if attention_mask is not None:
             attention_val = torch.masked_fill(attention_val, attention_mask == 0, float("-inf"))
           
         attention_weight = torch.softmax(attention_val, dim=-1)

--- a/content/zh/posts/2025-01-16-group-query-attention/group_query_attention.py
+++ b/content/zh/posts/2025-01-16-group-query-attention/group_query_attention.py
@@ -30,7 +30,7 @@ class GQABroadcast(nn.Module):
         self.v_proj = nn.Linear(hidden_dim, nums_kv_head * self.head_dim)
         self.output_proj = nn.Linear(hidden_dim, hidden_dim)
 
-    def forward(self, x, attention_mask= None):
+    def forward(self, x, attention_mask=None):
         batch_size, seq_len, _ = x.size()
         Q = self.q_proj(x)  # (batch_size, seq_len, hidden_dim)
         K = self.k_proj(x)  # (batch_size, seq_len, nums_kv_head * head_dim)

--- a/content/zh/posts/2025-01-16-group-query-attention/multi_query_attention.py
+++ b/content/zh/posts/2025-01-16-group-query-attention/multi_query_attention.py
@@ -36,7 +36,7 @@ class MultiQueryAttention(nn.Module):
         attention_val = (q @ k.transpose(-1, -2)) / math.sqrt(self.head_dim)
         print(f"attention_val  shape is {attention_val.size()}")
 
-        if  attention_mask is not None:
+        if attention_mask is not None:
             attention_val = torch.masked_fill(attention_val, attention_mask == 0, float("-inf"))
           
         attention_weight = torch.softmax(attention_val, dim=-1)


### PR DESCRIPTION
## Summary
- fix `attention_mask` spacing in group_query and multi_query modules

## Testing
- `python -m py_compile content/en/posts/2025-01-16-group-query-attention/group_query_attention.py content/zh/posts/2025-01-16-group-query-attention/group_query_attention.py content/en/posts/2025-01-16-group-query-attention/multi_query_attention.py content/zh/posts/2025-01-16-group-query-attention/multi_query_attention.py`


------
https://chatgpt.com/codex/tasks/task_e_68463c5f65e483228fea51b6b67834a5