### PR TITLE
Fix SEO placeholder leakage and dedupe Fancybox/JQuery head injection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -129,11 +129,9 @@ languages:
       math: true
       env: production
       title: "Yue Shui Blog"
-      description: "ExampleSite description"
+      description: "Yue Shui's personal blog on LLM algorithms, Agentic RL, and AI engineering."
       keywords: [Blog, Portfolio, PaperMod]
       author: "Yue Shui"
-
-      images: ["<link or path of image for opengraph, twitter-cards>"]
 
       DateFormat: "2006-01-02"
       ShowLastMod: true
@@ -158,12 +156,6 @@ languages:
       hidemeta: false
       hideSummary: false
 
-      assets:
-        favicon: "<link / abs url>"
-        favicon16x16: "<link / abs url>"
-        favicon32x32: "<link / abs url>"
-        apple_touch_icon: "<link / abs url>"
-        safari_pinned_tab: "<link / abs url>"
 
       label:
         text: "Home"
@@ -248,11 +240,9 @@ languages:
       math: true
       env: production
       title: "Yue Shui 博客"
-      description: "示例网站描述"
+      description: "Yue Shui 的个人博客，分享 LLM 算法、Agentic RL 与 AI 工程实践。"
       keywords: [博客, 作品集, PaperMod]
       author: "Yue Shui"
-
-      images: ["<opengraph、twitter-cards 图片的链接或路径>"]
 
       DateFormat: "2006-01-02"
       ShowLastMod: true
@@ -277,12 +267,6 @@ languages:
       hidemeta: false
       hideSummary: false
 
-      assets:
-        favicon: "<链接 / 绝对URL>"
-        favicon16x16: "<链接 / 绝对URL>"
-        favicon32x32: "<链接 / 绝对URL>"
-        apple_touch_icon: "<链接 / 绝对URL>"
-        safari_pinned_tab: "<链接 / 绝对URL>"
 
       label:
         text: "首页"

--- a/config.yaml
+++ b/config.yaml
@@ -129,7 +129,7 @@ languages:
       math: true
       env: production
       title: "Yue Shui Blog"
-      description: "Yue Shui 的个人博客，专注前沿 LLM 技术与研究论文解读，关注模型、算法与工程落地。"
+      description: "Yue Shui's personal blog on LLM algorithms, Agentic RL, and AI engineering."
       keywords: [Blog, Portfolio, PaperMod]
       author: "Yue Shui"
 
@@ -240,7 +240,7 @@ languages:
       math: true
       env: production
       title: "Yue Shui 博客"
-      description: "Yue Shui 的个人博客，专注前沿 LLM 技术与研究论文解读，关注模型、算法与工程落地。"
+      description: "Yue Shui 的个人博客，分享 LLM 算法、Agentic RL 与 AI 工程实践。"
       keywords: [博客, 作品集, PaperMod]
       author: "Yue Shui"
 

--- a/config.yaml
+++ b/config.yaml
@@ -129,7 +129,7 @@ languages:
       math: true
       env: production
       title: "Yue Shui Blog"
-      description: "Yue Shui's personal blog on LLM algorithms, Agentic RL, and AI engineering."
+      description: "Yue Shui 的个人博客，专注前沿 LLM 技术与研究论文解读，关注模型、算法与工程落地。"
       keywords: [Blog, Portfolio, PaperMod]
       author: "Yue Shui"
 
@@ -240,7 +240,7 @@ languages:
       math: true
       env: production
       title: "Yue Shui 博客"
-      description: "Yue Shui 的个人博客，分享 LLM 算法、Agentic RL 与 AI 工程实践。"
+      description: "Yue Shui 的个人博客，专注前沿 LLM 技术与研究论文解读，关注模型、算法与工程落地。"
       keywords: [博客, 作品集, PaperMod]
       author: "Yue Shui"
 

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,8 +1,3 @@
-{{ if .Page.Site.Params.fancybox }}
-  <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.css" />
-  <script src="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.js"></script>
-{{ end }}
 {{- /* Head custom content area start */ -}}
 {{- /*     Insert any custom code (web-analytics, resources, etc.) - it will appear in the <head></head> section of every page. */ -}}
 {{- /* Head custom content area end */ -}}
@@ -11,8 +6,7 @@
 {{ partial "mathjax.html" . }}
 {{ end }}
 
-{{if .Site.Params.fancybox }}
-<!-- Fancybox dependencies -->
+{{ if .Site.Params.fancybox }}
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.css" />
 <script src="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.js"></script>


### PR DESCRIPTION
### Motivation
- Prevent placeholder values from being rendered into production HTML (invalid favicon/OG images/descriptions) which were leaking from `config.yaml` into `public/` output.
- Remove duplicate `jquery`/`fancybox` injections in page `<head>` to avoid redundant network requests and improve performance.

### Description
- Replaced the placeholder `description` strings for both `en` and `zh` sites in `config.yaml` with real site descriptions and removed placeholder `images` and `assets` favicon blocks to stop invalid URLs from being emitted.
- Simplified `layouts/partials/extend_head.html` to keep a single conditional block that injects `jquery` and `fancybox` only once when `params.fancybox` is enabled.
- Changes were committed on the current branch as commit `6641f24` touching `config.yaml` and `layouts/partials/extend_head.html`.

### Testing
- Confirmed placeholder tokens no longer appear by running `rg` searches against `config.yaml`, which returned no matches for the placeholder strings.
- Inspected `layouts/partials/extend_head.html` to verify only one `jquery`/`fancybox` include block remains and the duplicate block was removed.
- Attempted to run `hugo --minify` for a full build verification but it failed because `hugo` is not installed in the environment (`bash: command not found: hugo`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699952ffb5108322bbfeb6b1a5127768)