### PR TITLE
Fix SEO placeholder leakage and dedupe Fancybox injections

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -129,11 +129,11 @@ languages:
       math: true
       env: production
       title: "Yue Shui Blog"
-      description: "ExampleSite description"
+      description: "Yue Shui’s personal blog exploring cutting-edge LLM technologies and research papers, with a focus on models, algorithms, and engineering."
       keywords: [Blog, Portfolio, PaperMod]
       author: "Yue Shui"
 
-      images: ["<link or path of image for opengraph, twitter-cards>"]
+      images: []
 
       DateFormat: "2006-01-02"
       ShowLastMod: true
@@ -157,13 +157,6 @@ languages:
       comments: true
       hidemeta: false
       hideSummary: false
-
-      assets:
-        favicon: "<link / abs url>"
-        favicon16x16: "<link / abs url>"
-        favicon32x32: "<link / abs url>"
-        apple_touch_icon: "<link / abs url>"
-        safari_pinned_tab: "<link / abs url>"
 
       label:
         text: "Home"
@@ -248,11 +241,11 @@ languages:
       math: true
       env: production
       title: "Yue Shui 博客"
-      description: "示例网站描述"
+      description: "Yue Shui 的个人博客，专注前沿 LLM 技术与研究论文分享，关注模型、算法与工程。"
       keywords: [博客, 作品集, PaperMod]
       author: "Yue Shui"
 
-      images: ["<opengraph、twitter-cards 图片的链接或路径>"]
+      images: []
 
       DateFormat: "2006-01-02"
       ShowLastMod: true
@@ -276,13 +269,6 @@ languages:
       comments: true
       hidemeta: false
       hideSummary: false
-
-      assets:
-        favicon: "<链接 / 绝对URL>"
-        favicon16x16: "<链接 / 绝对URL>"
-        favicon32x32: "<链接 / 绝对URL>"
-        apple_touch_icon: "<链接 / 绝对URL>"
-        safari_pinned_tab: "<链接 / 绝对URL>"
 
       label:
         text: "首页"

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,4 +1,4 @@
-{{ if .Page.Site.Params.fancybox }}
+{{ if .Site.Params.fancybox }}
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.css" />
   <script src="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.js"></script>
@@ -9,11 +9,4 @@
 
 {{ if or .Params.math .Site.Params.math }}
 {{ partial "mathjax.html" . }}
-{{ end }}
-
-{{if .Site.Params.fancybox }}
-<!-- Fancybox dependencies -->
-<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.css" />
-<script src="https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.js"></script>
 {{ end }}


### PR DESCRIPTION
### Motivation
- Prevent placeholder SEO fields (descriptions, images, favicons) from leaking into generated pages as invalid/encoded URLs.
- Remove duplicated Fancybox/jQuery head injections that caused double network requests and a performance regression.
- Ensure bilingual site descriptions are production-ready and match the provided copy.

### Description
- Replaced `languages.en.params.description` with the provided English sentence and `languages.zh.params.description` with the provided Chinese sentence in `config.yaml`.
- Cleared placeholder Open Graph image arrays by setting both `languages.*.params.images` to `[]` and removed the placeholder `assets` favicon block from both languages to avoid emitting invalid favicon URLs.
- Simplified `layouts/partials/extend_head.html` to use a single `{{ if .Site.Params.fancybox }}` block and removed the duplicate Fancybox/jQuery injection so assets are included only once.

### Testing
- Ran `rg -n` for the known placeholder patterns against `config.yaml` and `layouts/partials/extend_head.html`, which returned no matches indicating placeholders were removed.
- Attempted `hugo --gc --minify` to validate a production build but it failed in this environment with `hugo: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999663181808322a5627a6f9c9515be)