### PR TITLE
Normalize blog taxonomy vocabulary and clean inconsistent terms

### DIFF
--- a/TAXONOMY.md
+++ b/TAXONOMY.md
@@ -1,0 +1,24 @@
+# Taxonomy Vocabulary (Categories & Tags)
+
+This file defines the canonical taxonomy vocabulary for blog content.
+
+## Categories
+
+### English (`content/en/posts/**`)
+- `Technical Blog`
+
+### Chinese (`content/zh/posts/**`)
+- `技术博客`
+
+## Tag normalization rules
+
+Use these canonical spellings in front matter `tags`:
+
+- `LLM` (not `LLMs`)
+- `Deep Learning` (not `Deep learning`)
+
+## Migration mapping (applied)
+
+- `Tech Blog` -> `Technical Blog`
+- `LLMs` -> `LLM`
+- `Deep learning` -> `Deep Learning`

--- a/content/en/posts/2021-04-21-deep-learning-stock-prediction/index.md
+++ b/content/en/posts/2021-04-21-deep-learning-stock-prediction/index.md
@@ -2,7 +2,7 @@
 title: "Stock Price Prediction and Quantitative Strategy Based on Deep Learning"
 date: 2021-04-21T12:00:00+08:00
 author: "Yue Shui"
-tags: ["Deep learning", "AI", "RNN", "LSTM", "BiLSTM", "GRU", "LightGBM", "Neural Networks", "Stock Prediction", "Financial Modeling", "Machine Learning", "Quantitative Investment", "Portfolio Management", "Financial Engineering", "Algorithmic Trading", "Time Series"]
+tags: ["Deep Learning", "AI", "RNN", "LSTM", "BiLSTM", "GRU", "LightGBM", "Neural Networks", "Stock Prediction", "Financial Modeling", "Machine Learning", "Quantitative Investment", "Portfolio Management", "Financial Engineering", "Algorithmic Trading", "Time Series"]
 categories: ["Technical Blog"]
 toc: true
 ShowToc: true

--- a/content/en/posts/2024-12-21-build-gpu-server/index.md
+++ b/content/en/posts/2024-12-21-build-gpu-server/index.md
@@ -3,7 +3,7 @@ title: "Building a Home Deep Learning Rig with Dual RTX 4090 GPUs"
 date: 2024-12-21T12:00:00+08:00
 author: "Yue Shui"
 tags: ["Deep Learning", "AI", "LLM", "RTX 4090", "AI Hardware", "GPU"]
-categories: ["Tech Blog"]
+categories: ["Technical Blog"]
 # readingTime: 10
 ShowReadingTime: true
 toc: true

--- a/content/en/posts/2025-02-08-dpo/index.md
+++ b/content/en/posts/2025-02-08-dpo/index.md
@@ -2,7 +2,7 @@
 title: "LLMs Alignment: DPO"  
 date: 2025-02-08T12:00:00+08:00  
 author: "Yue Shui"  
-tags: ["AI", "NLP", "LLMs", "Post-training", "DPO", "RLHF", "Alignment", "Bradley–Terry Model"]  
+tags: ["AI", "NLP", "LLM", "Post-training", "DPO", "RLHF", "Alignment", "Bradley–Terry Model"]  
 categories: ["Technical Blog"]  
 readingTime: 25  
 toc: true  

--- a/content/en/posts/2025-03-01-train-llm/index.md
+++ b/content/en/posts/2025-03-01-train-llm/index.md
@@ -3,8 +3,8 @@ title: "Parallelism and Memory Optimization Techniques for Training Large Models
 date: 2025-03-01T12:00:00+08:00
 lastmod: 2025-03-01T12:00:00+08:00
 author: Yue Shui
-categories: ["Tech Blog"]
-tags: [LLMs, Pre-training, Distributed Training, Memory Optimization, Data Parallelism, Model Parallelism, Pipeline Parallelism, Tensor Parallelism, Sequence Parallelism, Hybrid Parallelism, Heterogeneous Systems, MoE, ZeRO, LoRA, AI, Deep Learning, AI Infrastructure]
+categories: ["Technical Blog"]
+tags: [LLM, Pre-training, Distributed Training, Memory Optimization, Data Parallelism, Model Parallelism, Pipeline Parallelism, Tensor Parallelism, Sequence Parallelism, Hybrid Parallelism, Heterogeneous Systems, MoE, ZeRO, LoRA, AI, Deep Learning, AI Infrastructure]
 readingTime: 60
 toc: true
 ShowToc: true

--- a/content/en/posts/2025-05-17-vllm/index.md
+++ b/content/en/posts/2025-05-17-vllm/index.md
@@ -4,7 +4,7 @@ date: 2025-05-17T10:00:00+08:00
 lastmod: 2025-05-17T10:00:00+08:00
 author: "Yue Shui"
 categories: ["Technical Blog"]
-tags: ["vLLM", "PagedAttention", "LLM Serving", "Inference", "KV Cache", "Memory Optimization", "LLMs", "AI Infrastructure", "Deep Learning"]
+tags: ["vLLM", "PagedAttention", "LLM Serving", "Inference", "KV Cache", "Memory Optimization", "LLM", "AI Infrastructure", "Deep Learning"]
 ShowReadingTime: true
 toc: true
 ShowToc: true

--- a/content/zh/posts/2021-04-21-deep-learning-stock-prediction/index.md
+++ b/content/zh/posts/2021-04-21-deep-learning-stock-prediction/index.md
@@ -2,7 +2,7 @@
 title: "基于深度学习的股票价格预测和量化策略"
 date: 2021-04-21T12:00:00+08:00
 author: "Yue Shui"
-tags: ["Deep learning", "AI", "RNN", "LSTM", "BiLSTM", "GRU", "LightGBM", "Neural Networks", "Stock Prediction", "Financial Modeling", "Machine Learning", "Quantitative Investment", "Portfolio Management", "Financial Engineering", "Algorithmic Trading", "Time Series"]
+tags: ["Deep Learning", "AI", "RNN", "LSTM", "BiLSTM", "GRU", "LightGBM", "Neural Networks", "Stock Prediction", "Financial Modeling", "Machine Learning", "Quantitative Investment", "Portfolio Management", "Financial Engineering", "Algorithmic Trading", "Time Series"]
 categories: ["技术博客"]
 toc: true
 ShowToc: true

--- a/content/zh/posts/2025-03-01-train-llm/index.md
+++ b/content/zh/posts/2025-03-01-train-llm/index.md
@@ -4,7 +4,7 @@ date: 2025-03-01T12:00:00+08:00
 lastmod: 2025-03-01T12:00:00+08:00
 author: Yue Shui
 categories: ["技术博客"]
-tags: [LLMs, 预训练, 分布式训练, 内存优化, 数据并行, 模型并行, 流水线并行, 张量并行, 序列并行, 混合并行, 异构系统, MoE, ZeRO, LoRA, AI, 深度学习, AI Infrastructure]
+tags: [LLM, 预训练, 分布式训练, 内存优化, 数据并行, 模型并行, 流水线并行, 张量并行, 序列并行, 混合并行, 异构系统, MoE, ZeRO, LoRA, AI, 深度学习, AI Infrastructure]
 readingTime: 60
 toc: true
 ShowToc: true

--- a/content/zh/posts/2025-05-17-vllm/index.md
+++ b/content/zh/posts/2025-05-17-vllm/index.md
@@ -4,7 +4,7 @@ date: 2025-05-17T10:00:00+08:00
 lastmod: 2025-05-17T10:00:00+08:00
 author: "Yue Shui"
 categories: ["技术博客"]
-tags: ["PagedAttention", "LLM Serving", "Inference", "KV Cache", "Memory Optimization", "LLMs", "AI Infrastructure"]
+tags: ["PagedAttention", "LLM Serving", "Inference", "KV Cache", "Memory Optimization", "LLM", "AI Infrastructure"]
 ShowReadingTime: true
 toc: true
 ShowToc: true


### PR DESCRIPTION
### Motivation

- 解决分类与标签命名不一致导致的 taxonomy 碎片化，从而使相关文章无法在同一分类/标签页汇聚。
- 建立并记录一份规范词表，方便后续内容维护与批量校正。 

### Description

- 新增 `TAXONOMY.md`，定义中英文分类规范与标签标准写法，并列出迁移映射（`Tech Blog` → `Technical Blog`，`LLMs` → `LLM`，`Deep learning` → `Deep Learning`）。
- 批量修改若干文章 front matter，将英文分类 `Tech Blog` 统一为 `Technical Blog`，并将标签中的 `LLMs`/`Deep learning` 等变体规范化为 `LLM` / `Deep Learning`，变更影响 EN/ZH 受影响文章若干（共 9 文件变更，含新增 `TAXONOMY.md`）。
- 所有更改均为 front matter 元数据规范化，不改动文章正文内容或站点模板。 

### Testing

- 使用脚本扫描并统计 `content/en/posts/**/index.md` 与 `content/zh/posts/**/index.md` 中的 `categories` 与 `tags`，验证 EN 分类已统一为 `Technical Blog` 且 `LLMs` 标签已清零，脚本检查通过。 
- 已执行 `git commit` 并提交变更，提交信息为 `Normalize taxonomy vocabulary across posts`，提交成功。 
- 尝试运行 `hugo --gc --minify` 进行构建验证，但当前环境未安装 `hugo`（`bash: command not found: hugo`），因此无法在此环境完成站点构建验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb3b4309c832285adb0eb0acaeeee)